### PR TITLE
Remove unused dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See the provided [Makefile](Makefile) for convenient targets:
 - `make doc` to build HTML documentation from docstrings (requires `pdoc`)
 - `make format` to autoformat the code (requires `black` and `isort`)
 - `make lint` to check code quality (requires `flake8` and `Flake8-pyproject`)
-- `make type` to typecheck the code (requires `mypy` and `types-setuptools`)
+- `make type` to typecheck the code (requires `mypy`)
 - `make test` to run unit tests
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Documentation = "https://ncanceill.github.io/snakeling"
 dev = ["build", "setuptools", "setuptools-scm"]
 doc = ["pdoc"]
 quality = ["black", "flake8", "Flake8-pyproject", "isort"]
-testing = ["mypy", "types-setuptools"]
+testing = ["mypy"]
 
 [tool.flake8]
 exclude = ["build", "venv"]


### PR DESCRIPTION
`types-setuptools` is not needed because `setuptools` is not directly imported